### PR TITLE
Fix warnings when vintage_net_wizard is optional

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -10,6 +10,7 @@ defmodule NervesPack.MixProject do
       version: @version,
       elixir: "~> 1.7",
       start_permanent: Mix.env() == :prod,
+      xref: [exclude: [Circuits.GPIO, VintageNetWizard]],
       dialyzer: dialyzer(),
       deps: deps(),
       docs: docs(),


### PR DESCRIPTION
Including nerves_pack in a new project that does not have `vintage_net_wizard` will cause warnings to be emitted:

```elixir
==> nerves_pack
Compiling 4 files (.ex)
warning: function Circuits.GPIO.open/2 is undefined (module Circuits.GPIO is not available)
  lib/nerves_pack/wifi_wizard_button.ex:86

warning: function Circuits.GPIO.set_interrupts/2 is undefined (module Circuits.GPIO is not available)
  lib/nerves_pack/wifi_wizard_button.ex:87

warning: function VintageNetWizard.run_wizard/0 is undefined (module VintageNetWizard is not available)
Found at 2 locations:
  lib/nerves_pack/application.ex:99
  lib/nerves_pack/wifi_wizard_button.ex:122
```

This PR compiles out the calls if vintage_net_wizard is not added as a dependency to the top project.