### PR TITLE
Supervise sshd and allow port to be specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,28 @@ config :shoehorn,
   app: Mix.Project.config()[:app]
 ```
 
+## SSH Console Port
+
+By default, `nerves_pack` will start an IEx console on port 22, this can be overriden
+by specifying `:ssh_console_port` in the config. The SFTP subsystem is also enabled
+so that you can transfer files back and forth as well. To disable this feature,
+set `:ssh_console_port` to `nil`.  This console will use the same ssh public
+keys as those configured for `:nerves_firmware_ssh`. Usernames are ignored.
+
+```elixir
+config :nerves_pack, ssh_console_port: 2222
+```
+
+Connect by running:
+
+```bash
+ssh nerves.local
+```
+
+To exit the SSH session, type `~.`. This is an `ssh` escape sequence (See the
+[ssh man page](https://linux.die.net/man/1/ssh) for other escape sequences).
+Typing `Ctrl+D` or `logoff` at the IEx prompt to exit the session won't work.
+
 ## Optional WiFi Wizard Setup
 
 _When_ and _how_ to start the WiFi wizard is generally very dependent on your

--- a/README.md
+++ b/README.md
@@ -37,16 +37,16 @@ config :shoehorn,
   app: Mix.Project.config()[:app]
 ```
 
-## SSH Console Port
+## SSH Port
 
 By default, `nerves_pack` will start an IEx console on port 22, this can be overriden
-by specifying `:ssh_console_port` in the config. The SFTP subsystem is also enabled
+by specifying `:ssh_port` in the config. The SFTP subsystem is also enabled
 so that you can transfer files back and forth as well. To disable this feature,
-set `:ssh_console_port` to `nil`.  This console will use the same ssh public
+set `:ssh_port` to `nil`.  This console will use the same ssh public
 keys as those configured for `:nerves_firmware_ssh`. Usernames are ignored.
 
 ```elixir
-config :nerves_pack, ssh_console_port: 2222
+config :nerves_pack, ssh_port: 2222
 ```
 
 Connect by running:
@@ -55,7 +55,7 @@ Connect by running:
 ssh nerves.local
 ```
 
-To exit the SSH session, type `~.`. This is an `ssh` escape sequence (See the
+To exit the SSH session, type `exit` or type the ssh escape sequence `~.` . (See the
 [ssh man page](https://linux.die.net/man/1/ssh) for other escape sequences).
 Typing `Ctrl+D` or `logoff` at the IEx prompt to exit the session won't work.
 

--- a/lib/nerves_pack/application.ex
+++ b/lib/nerves_pack/application.ex
@@ -8,8 +8,10 @@ defmodule NervesPack.Application do
     _ = configure_networking()
     _ = configure_mdns()
 
+    ssh_console_port = Application.get_env(:nerves_pack, :ssh_console_port, 22)
+
     children =
-      [NervesPack.SSH]
+      [{NervesPack.SSH, %{ssh_console_port: ssh_console_port}}]
       |> add_wifi_wizard_button()
 
     opts = [strategy: :one_for_one, name: NervesPack.Supervisor]

--- a/lib/nerves_pack/application.ex
+++ b/lib/nerves_pack/application.ex
@@ -8,10 +8,10 @@ defmodule NervesPack.Application do
     _ = configure_networking()
     _ = configure_mdns()
 
-    ssh_console_port = Application.get_env(:nerves_pack, :ssh_console_port, 22)
+    ssh_port = Application.get_env(:nerves_pack, :ssh_port, 22)
 
     children =
-      [{NervesPack.SSH, %{ssh_console_port: ssh_console_port}}]
+      [{NervesPack.SSH, %{ssh_port: ssh_port}}]
       |> add_wifi_wizard_button()
 
     opts = [strategy: :one_for_one, name: NervesPack.Supervisor]

--- a/lib/nerves_pack/ssh.ex
+++ b/lib/nerves_pack/ssh.ex
@@ -19,9 +19,9 @@ defmodule NervesPack.SSH do
   use GenServer
 
   @doc """
-  Start an ssh daemon if ssh_console_port is not nil
+  Start an ssh daemon if ssh_port is not nil
   """
-  def start_link(%{ssh_console_port: nil}), do: :ignore
+  def start_link(%{ssh_port: nil}), do: :ignore
 
   def start_link(opts) do
     GenServer.start_link(__MODULE__, [opts], name: __MODULE__)
@@ -32,9 +32,9 @@ defmodule NervesPack.SSH do
     start_ssh(opts)
   end
 
-  @spec start_ssh(%{:ssh_console_port => any}) ::
+  @spec start_ssh(%{:ssh_port => any}) ::
           {:ok, :ssh.daemon_ref()} | {:stop, reason :: any()}
-  defp start_ssh(%{ssh_console_port: ssh_console_port}) do
+  defp start_ssh(%{ssh_port: ssh_port}) do
     # Reuse `nerves_firmware_ssh` keys
     authorized_keys =
       Application.get_env(:nerves_firmware_ssh, :authorized_keys, [])
@@ -50,7 +50,7 @@ defmodule NervesPack.SSH do
 
     # Reuse the system_dir as well to allow for auth to work with the shared
     # keys.
-    case :ssh.daemon(ssh_console_port, [
+    case :ssh.daemon(ssh_port, [
            {:id_string, :random},
            {:key_cb, {Nerves.Firmware.SSH.Keys, cb_opts}},
            {:system_dir, Nerves.Firmware.SSH.Application.system_dir()},


### PR DESCRIPTION
When switching from nerves_init_gadget there were a couple of sshd features, that differ:
1. The ability to specify the sshd port
2. More robust supervision of sshd, See https://github.com/nerves-project/nerves_init_gadget/pull/63 for history. 

I chose the same config options as nerves_init_gadget but am open to naming changes or any other suggestions.

I did a copy/paste of the relevant readme sections as well. I find the `~.` still useful but this could possible be updated to reference `exit` from `Toolshed`