### PR TITLE
start as distributed node

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,8 +43,9 @@ jobs:
           keys:
             - v1-mix-cache-{{ checksum "mix.lock" }}
       - run: mix deps.get
-      - run: mix compile
+      - run: mix compile --warnings-as-errors
       - run: mix format --check-formatted
+      - run: mix test
       - run: mix docs
       - run: mix hex.build
       - run: mix dialyzer --halt-exit-status

--- a/README.md
+++ b/README.md
@@ -37,6 +37,55 @@ config :shoehorn,
   app: Mix.Project.config()[:app]
 ```
 
+## Erlang Distribution
+
+You can use `nerves_pack` to run your device as a distributed node by default
+via configuration or at runtime with `NervesPack.Node.start/2`.
+
+To run on startup, give your device a node name:
+
+```elixir
+config :nerves_pack, node_name: "mydevice"
+```
+
+Optionally, you can also specify how you would like the host configured and
+`NervesPack` will do a best-effort attempt to configure the node accordingly:
+
+```elixir
+config :nerves_pack,
+  node_name: "mydevice",
+  node_host: :mdns
+```
+
+Supported `:host` options are:
+* `:mdns` - Use the `host` set for `MdnsLite`. This will be in `*.local` form
+* `:ip` - Read the IP address of the device. If multiple interfaces are
+  connected, it will cycle through IP addresses on each interface and select the
+  first one found preferring the order of `ethernet`, `wifi`, then `usb`
+* `:dhcp` - Reads the assigned dhcp address based on the device hostname
+* `:hostname` - Reads hostname of the device, assigning as `hostname.local`
+* custom binary created by the user representing the host - `"testing.local"`
+
+You can also skip any sort of deduction by `:nerves_pack` and supply a valid
+node atom as well:
+
+```elixir
+config :nerves_pack, node_name: :"mydevice@nerves.local"
+```
+
+If you do not want `NervesPack` to handle starting as a distributed node, you
+can skip application configuration and instead call at runtime:
+
+```elixir
+NervesPack.Node.start("mynode", host: :mdns)
+```
+
+See `NervesPack.Node.start/2` for more info.
+
+It's also worth noting that _nerves <-> nerves_ communication won't work with
+`:mdns` because the Erlang DNS resolver doesn't handle it and you may want to
+use `:dhcp` or `:ip` with static addresses to handle it.
+
 ## SSH Port
 
 By default, `nerves_pack` will start an IEx console on port 22, this can be overriden

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,0 +1,26 @@
+use Mix.Config
+
+# Overrides for unit tests:
+config :mdns_lite, skip_udp: true
+
+config :nerves_runtime, :kernel, autoload_modules: false
+config :nerves_runtime, target: "host"
+
+config :nerves_runtime, Nerves.Runtime.KV.Mock, %{
+  "nerves_fw_active" => "a",
+  "a.nerves_fw_uuid" => "8a8b902c-d1a9-58aa-6111-04ab57c2f2a8",
+  "a.nerves_fw_product" => "nerves_pack"
+}
+
+config :nerves_runtime, :modules, [
+  {Nerves.Runtime.KV, Nerves.Runtime.KV.Mock}
+]
+
+config :vintage_net,
+  udhcpc_handler: VintageNetTest.CapturingUdhcpcHandler,
+  udhcpd_handler: VintageNetTest.CapturingUdhcpdHandler,
+  resolvconf: "/dev/null",
+  persistence_dir: "./test_tmp/persistence",
+  bin_ip: "false"
+
+config :nerves_pack, ssh_port: 2222

--- a/lib/nerves_pack/application.ex
+++ b/lib/nerves_pack/application.ex
@@ -7,6 +7,7 @@ defmodule NervesPack.Application do
   def start(_type, _args) do
     _ = configure_networking()
     _ = configure_mdns()
+    _ = start_distribution()
 
     ssh_port = Application.get_env(:nerves_pack, :ssh_port, 22)
 
@@ -79,6 +80,22 @@ defmodule NervesPack.Application do
             "[NervesPack] No default interface configuration is available for #{ifname} - Skipping.."
           )
       end
+    end
+  end
+
+  def start_distribution() do
+    node_name = Application.get_env(:nerves_pack, :node_name)
+    node_host = Application.get_env(:nerves_pack, :node_host)
+
+    case NervesPack.Node.start(node_name, host: node_host) do
+      {:ok, _node} ->
+        Logger.info("[NervesPack] Started as distributed node")
+
+      {:error, {:already_started, _}} ->
+        Logger.info("[NervesPack] Already started as distributed node")
+
+      {:error, err} ->
+        Logger.error("[NervesPack] Failed to start as distributed node: #{inspect(err)}")
     end
   end
 end

--- a/lib/nerves_pack/node.ex
+++ b/lib/nerves_pack/node.ex
@@ -1,0 +1,119 @@
+defmodule NervesPack.Node do
+  @type node_name :: atom() | charlist() | binary()
+  @type node_host :: :dhcp | :hostname | :ip | :mdns | binary()
+
+  @type node_return :: {:ok, pid()} | {:error, term()}
+
+  defdelegate stop(), to: Node
+
+  @doc """
+  Start as a distributed node.
+
+  Requires a valid node as the argument. i.e. `:"howdy@nerves.local"` or
+  specifying the name for the node
+
+  ```elixir
+  start("howdy", host: :ip)
+  ```
+
+  Options:
+    * `:host` - Host to use for the node. Supports `:ip`, `:dhcp`, `:hostname`
+      or any binary or charlist
+    * `:force` - Force node to be stopped if already running
+    * `:type` - See Node.start/3
+    * `:tick_time` - See Node.start/3
+  """
+  @spec start(node(), keyword(host: node_host())) :: node_return()
+  def start(node_name, opts \\ []) do
+    build_node(node_name, opts[:host])
+    |> start_node(opts)
+  end
+
+  defp build_node(nil, _host), do: nil
+
+  defp build_node(node, node_host) when is_atom(node) do
+    node_str = to_string(node)
+
+    if String.contains?(node_str, "@") do
+      node
+    else
+      build_node(node_str, node_host)
+    end
+  end
+
+  defp build_node(node_name, node_host) do
+    node_host = resolve_node_host(node_host)
+
+    if node_name && node_host do
+      :"#{node_name}@#{node_host}"
+    end
+  end
+
+  defp resolve_node_host(nil), do: resolve_node_host(:mdns)
+
+  defp resolve_node_host(:mdns) do
+    case MdnsLite.Configuration.get_mdns_config() do
+      %{host: :hostname} -> resolve_node_host(:hostname)
+      %{host: host} -> "#{host}.local"
+      _ -> resolve_node_host(:ip)
+    end
+  end
+
+  defp resolve_node_host(:dhcp) do
+    with {:ok, hostname} <- :inet.gethostname(),
+         {:ok, {:hostent, dhcp_name, _, _, _, _}} <- :inet.gethostbyname(hostname) do
+      dhcp_name
+    else
+      _ -> resolve_node_host(:ip)
+    end
+  end
+
+  defp resolve_node_host(:hostname) do
+    {:ok, host} = :inet.gethostname()
+    "#{host}.local"
+  end
+
+  defp resolve_node_host(:ip) do
+    ips =
+      VintageNet.match(["interface", :_, "addresses"])
+      # Simplify structure a bit to {ifname, addresses}
+      |> Enum.map(fn {[_, ifname, _], addrs} -> {ifname, addrs} end)
+      |> Enum.sort()
+
+    # Run through all known connected IP addresses prefering the order
+    # of ethernet, wlan, then USB and halt on the first one discovered
+    Enum.reduce_while(["eth", "wlan", "usb"], nil, fn ifname, acc ->
+      case Enum.find(ips, &String.starts_with?(elem(&1, 0), ifname)) do
+        {_, [%{address: addr} | _tail]} ->
+          {:halt, VintageNet.IP.ip_to_string(addr)}
+
+        _ ->
+          {:cont, acc}
+      end
+    end)
+  end
+
+  defp resolve_node_host(host) when is_binary(host), do: host
+
+  defp resolve_node_host(_host), do: nil
+
+  defp start_epmd() do
+    :os.cmd('epmd -daemon')
+  end
+
+  defp start_node(node, opts) when is_atom(node) and not is_nil(node) do
+    # Aggressibely ensure epmd daemon is running
+    # noop if daemon is already started
+    _ = start_epmd()
+
+    # Force the node to stop and restart with new settings
+    _ = if opts[:force] == true, do: stop()
+
+    args = [node | Keyword.take(opts, [:type, :tick_time])]
+    apply(Node, :start, args)
+  end
+
+  defp start_node(node, _opts) do
+    {:error, "Bad node: #{inspect(node)}"}
+  end
+end

--- a/test/node_test.exs
+++ b/test/node_test.exs
@@ -1,0 +1,76 @@
+defmodule NervesPack.NodeTest do
+  use ExUnit.Case, async: true
+
+  alias VintageNet.PropertyTable, as: PropTable
+
+  @ip "192.168.0.1"
+
+  describe "start/2" do
+    setup do
+      formatted = VintageNet.IP.ip_to_tuple!(@ip)
+      PropTable.put(VintageNet, ["interface", "eth0", "addresses"], [%{address: formatted}])
+
+      {:ok, hostname} = :inet.gethostname()
+
+      %{hostname: hostname}
+    end
+
+    test "default", %{hostname: hostname} do
+      NervesPack.Node.start(:test, force: true)
+
+      assert node() == :"test@#{hostname}.local"
+    end
+
+    test "IP" do
+      NervesPack.Node.start(:test, host: :ip, force: true)
+
+      assert node() == :"test@#{@ip}"
+    end
+
+    test "dchp", %{hostname: hostname} do
+      NervesPack.Node.start(:test, host: :dhcp, force: true)
+
+      assert node() == :"test@#{hostname}"
+    end
+
+    test "mdns", %{hostname: hostname} do
+      NervesPack.Node.start(:test, host: :mdns, force: true)
+
+      assert node() == :"test@#{hostname}.local"
+    end
+
+    test "hostname", %{hostname: hostname} do
+      NervesPack.Node.start(:test, host: :hostname, force: true)
+
+      assert node() == :"test@#{hostname}.local"
+    end
+
+    test "full node name" do
+      NervesPack.Node.start(:"full@nerves.local", force: true)
+
+      assert node() == :"full@nerves.local"
+    end
+
+    test "various node name types", %{hostname: hostname} do
+      # binary
+      NervesPack.Node.start("howdy", force: true)
+
+      assert node() == :"howdy@#{hostname}.local"
+
+      # atom
+      NervesPack.Node.start(:howdy, force: true)
+
+      assert node() == :"howdy@#{hostname}.local"
+
+      # charlist
+      NervesPack.Node.start('howdy', force: true)
+
+      assert node() == :"howdy@#{hostname}.local"
+    end
+
+    test "errors with nil node name" do
+      assert NervesPack.Node.start(nil) ==
+               {:error, "Bad node: nil"}
+    end
+  end
+end


### PR DESCRIPTION
There is a fair amount more work to probably do here, but this gets the ball rolling.

Specifically, we'll need to handle mDNS differently in order to get **_nerves <-> nerves_** communication working with mDNS addresses.

Also don't know if I _love_ this implementation, so would appreciate feedback. This patterns a bit after `nerves_init_gadget` for more simple configuration and fallbacks, but really we could just add a single line to start `epmd` and call it good as well.