### PR TITLE
Remove automatic network configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,7 @@ getting a Nerves project up and running with minimal work. Essentially
 
 When added to your project, the following services are enabled by default:
 
-* **Networking** - Utilizes `VintageNet`. Ethernet and USB Direct are started by
-  default if a supporting interface is discovered on the device
+* **Networking** - Utilizes `VintageNet`
 * **mDNS** - via `MdnsLite`. Supports `nerves.local` and the default hostname (i.e.
   `nerves-1234.local`) This is also configurable to other hostnames as well.
 * **SSH** - Includes SSH access, firmware updates over SSH, and SFTP

--- a/lib/nerves_pack/application.ex
+++ b/lib/nerves_pack/application.ex
@@ -2,10 +2,8 @@ defmodule NervesPack.Application do
   @moduledoc false
 
   use Application
-  require Logger
 
   def start(_type, _args) do
-    _ = configure_networking()
     _ = configure_mdns()
 
     ssh_port = Application.get_env(:nerves_pack, :ssh_port, 22)
@@ -56,29 +54,6 @@ defmodule NervesPack.Application do
     unless mdns_config[:host] do
       Keyword.get(nerves_pack_config, :host, [:hostname, "nerves"])
       |> MdnsLite.set_host()
-    end
-  end
-
-  defp configure_networking() do
-    configured = VintageNet.configured_interfaces()
-
-    all =
-      VintageNet.all_interfaces()
-      |> Enum.reject(&String.starts_with?(&1, "lo"))
-
-    for ifname <- all, ifname not in configured do
-      case ifname do
-        "eth" <> _ ->
-          VintageNet.configure(ifname, %{type: VintageNetEthernet})
-
-        "usb" <> _ ->
-          VintageNet.configure(ifname, %{type: VintageNetDirect})
-
-        _ ->
-          Logger.warn(
-            "[NervesPack] No default interface configuration is available for #{ifname} - Skipping.."
-          )
-      end
     end
   end
 end


### PR DESCRIPTION
This interferes with deterministic networking since the automated
network configuration logic triggers off the default names.

Given that the new project generator puts a default configuration in the
config.exs, I wouldn't expect this logic to be used much any more.