### PR TITLE
docs env and CI version bumps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,9 +28,9 @@ defaults: &defaults
 jobs:
   build_elixir_1_10_otp_23:
     docker:
-      - image: erlang:23.0.1
+      - image: erlang:23.0.3
         environment:
-          ELIXIR_VERSION: 1.10.3-otp-23
+          ELIXIR_VERSION: 1.10.4-otp-23
           LC_ALL: C.UTF-8
           SUDO: true
     <<: *defaults

--- a/mix.exs
+++ b/mix.exs
@@ -14,7 +14,12 @@ defmodule NervesPack.MixProject do
       deps: deps(),
       docs: docs(),
       description: "Initialization setup for Nerves devices",
-      package: package()
+      package: package(),
+      preferred_cli_env: %{
+        docs: :docs,
+        "hex.build": :docs,
+        "hex.publish": :docs
+      }
     ]
   end
 
@@ -45,7 +50,7 @@ defmodule NervesPack.MixProject do
 
       # Dev Dependencies
       {:dialyxir, "~> 1.0.0", only: :dev, runtime: false},
-      {:ex_doc, "~> 0.22", only: [:dev, :test], runtime: false}
+      {:ex_doc, "~> 0.22", only: :docs, runtime: false}
     ]
   end
 


### PR DESCRIPTION
* move `ex_doc` to `:docs` env with `preferred_cli_env` aliases (like other projects)
* bump CI versions for elixir 1.10.4 and Erlang 23.0.2