### PR TITLE
Force upgrades to vintage_net and mdns_lite

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -40,11 +40,11 @@ defmodule NervesPack.MixProject do
       {:nerves_time, "~> 0.3"},
       {:nerves_motd, "~> 0.1"},
       {:ring_logger, "~> 0.8"},
-      {:vintage_net, "~> 0.7"},
-      {:vintage_net_direct, "~> 0.7"},
-      {:vintage_net_ethernet, "~> 0.7"},
-      {:vintage_net_wifi, "~> 0.7"},
-      {:mdns_lite, "~> 0.6"},
+      {:vintage_net, "~> 0.10"},
+      {:vintage_net_direct, "~> 0.10"},
+      {:vintage_net_ethernet, "~> 0.10"},
+      {:vintage_net_wifi, "~> 0.10"},
+      {:mdns_lite, "~> 0.10"},
 
       # Dev dependencies
       {:dialyxir, "~> 1.1.0", only: :dev, runtime: false},


### PR DESCRIPTION
The older versions of these libraries have bugs that are tough to
support so force users to upgrade.
