### PR TITLE
Remove docs-only BEAM file

### DIFF
--- a/lib/nerves_pack.ex
+++ b/lib/nerves_pack.ex
@@ -1,3 +1,0 @@
-defmodule NervesPack do
-  @moduledoc File.read!("README.md")
-end

--- a/mix.exs
+++ b/mix.exs
@@ -58,7 +58,6 @@ defmodule NervesPack.MixProject do
     %{
       files: [
         "CHANGELOG.md",
-        "lib",
         "LICENSE",
         "mix.exs",
         "README.md"


### PR DESCRIPTION
While it's small (3-4 KB), it's just one more file to load for embedded
mode releases.
