### PR TITLE
Update HexDoc URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ This also brings in the switch from `nerves_firmware_ssh` to
 `ssh_subsystem_fwup` which moves firmware updates from port 8989 to an
 SSH subsystem on port 22. This is a breaking change for scripts that
 load firmware to Nerves devices via SSH. See the
-[`Upgrade from NervesFirmwareSSH`](https://hexdocs.pm/nerves_ssh/readme.html#upgrade-from-nervesfirmwaressh)
+[`Upgrade from NervesFirmwareSSH`](https://nerves-ssh.hexdocs.pm/readme.html#upgrade-from-nervesfirmwaressh)
 doc for more details on how to handle this change.
 
 ## v0.3.3
@@ -56,7 +56,7 @@ doc for more details on how to handle this change.
 This allows `v0.9` of the `vintage_net*` libraries.
 
 If you wish to update the `vintage_net*` libraries, be sure to look at
-the [VintageNet `v0.9.0` Changelog](https://hexdocs.pm/vintage_net/changelog.html#v0-9-0)
+the [VintageNet `v0.9.0` Changelog](https://vintage-net.hexdocs.pm/changelog.html#v0-9-0)
 as there are a few breaking changes that might need to be considered.
 
 ## v0.3.2
@@ -83,7 +83,7 @@ This release removes the `vintage_net_wizard` setup helper. It turned out that
 there was enough custom configuration that it was easier to configure the WiFi
 wizard on its own rather than via `NervesPack`. If you had been using
 `NervesPack` to configure the wizard, please see the [`vintage_net_wizard`
-docs](https://hexdocs.pm/vintage_net_wizard).
+docs](https://vintage-net-wizard.hexdocs.pm).
 
 ## v0.2.2
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Nerves Pack
 
 [![Hex version](https://img.shields.io/hexpm/v/nerves_pack.svg "Hex version")](https://hex.pm/packages/nerves_pack)
-[![API docs](https://img.shields.io/hexpm/v/nerves_pack.svg?label=hexdocs "API docs")](https://hexdocs.pm/nerves_pack/NervesPack.html)
+[![API docs](https://img.shields.io/hexpm/v/nerves_pack.svg?label=hexdocs "API docs")](https://nerves-pack.hexdocs.pm/NervesPack.html)
 [![CircleCI](https://circleci.com/gh/nerves-project/nerves_pack.svg?style=svg)](https://circleci.com/gh/nerves-project/nerves_pack)
 [![REUSE status](https://api.reuse.software/badge/github.com/nerves-project/nerves_pack)](https://api.reuse.software/info/github.com/nerves-project/nerves_pack)
 
@@ -114,7 +114,7 @@ error directing you to update your configuration.
 
 The use of SSH public keys lets you log into your Nerves devices, but no one
 else.  See [the
-docs](https://hexdocs.pm/nerves_firmware_ssh/readme.html#installation) for how
+docs](https://nerves-firmware-ssh.hexdocs.pm/readme.html#installation) for how
 to configure your keys). Usernames are ignored.
 
 Connect by running:
@@ -203,5 +203,5 @@ iex(nerves@nerves.local)6>
 _When_ and _how_ to start the WiFi wizard is generally very dependent on your
 use-case so it's recommended that you implement the startup logic on your own.
 
-See the [`vintage_net_wizard` docs](https://hexdocs.pm/vintage_net_wizard) for
+See the [`vintage_net_wizard` docs](https://vintage-net-wizard.hexdocs.pm) for
 more information on use and configuration.


### PR DESCRIPTION
Migrates HexDocs URLs to the 2026 format using hex_url_migrator.

<details>
<summary>⚠️ URL verification warnings from <code>hex_url_migrator --verify</code></summary>

```
❌ Verification failed for https://vintage-net-wizard.hexdocs.pm): %Req.TransportError{reason: :nxdomain}
❌ Verification failed for https://nerves-pack.hexdocs.pm/NervesPack.html): Status 404
⚠️ Verification finished: 3 success, 2 failure(s).
```

_Reported by the migrator's verifier. Note that `301`s are typically redirects (the target exists) and a trailing `)` is a markdown-link parsing artifact. Please review before merging._
</details>